### PR TITLE
add min and max values to roll & pitch

### DIFF
--- a/Parallax/ACParallaxView.m
+++ b/Parallax/ACParallaxView.m
@@ -115,7 +115,21 @@ static CMMotionManager *sharedMotionManager;
                  
                  self.relativeAttitude = attitude;
                  
-                 //TODO: fix crazy values, especially when changing pitch
+                 if (attitude.pitch>1.0f) {
+                     attitude.pitch = 1.0f;
+                 }
+                 
+                 if (attitude.pitch<=-1.0f) {
+                     attitude.pitch = -1.0f;
+                 }
+                 
+                 if (attitude.roll>1.0f) {
+                     attitude.roll = 1.0f;
+                 }
+                 
+                 if (attitude.roll<=-1.0f) {
+                     attitude.roll = -1.0f;
+                 }
                  
                  CATransform3D transform = CATransform3DIdentity;
 

--- a/Parallax/ACParallaxView.m
+++ b/Parallax/ACParallaxView.m
@@ -115,20 +115,20 @@ static CMMotionManager *sharedMotionManager;
                  
                  self.relativeAttitude = attitude;
                  
-                 if (attitude.pitch>1.0f) {
-                     attitude.pitch = 1.0f;
+                 if (attitude.pitch>0.6) {
+                     attitude.pitch = 0.6;
                  }
                  
-                 if (attitude.pitch<=-1.0f) {
-                     attitude.pitch = -1.0f;
+                 if (attitude.pitch<=-0.6f) {
+                     attitude.pitch = -0.6f;
                  }
                  
-                 if (attitude.roll>1.0f) {
-                     attitude.roll = 1.0f;
+                 if (attitude.roll>0.6) {
+                     attitude.roll = 0.6;
                  }
                  
-                 if (attitude.roll<=-1.0f) {
-                     attitude.roll = -1.0f;
+                 if (attitude.roll<=-0.6f) {
+                     attitude.roll = -0.6f;
                  }
                  
                  CATransform3D transform = CATransform3DIdentity;


### PR DESCRIPTION
this change is more a hack than a fix, but i wanted to avoid the white background in the corners when the values are offscale (usually higher than 0.6 causes it). do you have any other suggestions on limiting the parallax effect? 

I also tried assigning the `ACParallaxView` view a bigger frame, however, the issue with the white background persisted. 
